### PR TITLE
#30 for RPC_URL var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ CIRCUITS_PATH="./circuits"
 WALLET_KEY="" 
 # MongoDB connection string, uses in memory Mongo server if not specified
 MONGO_DB_CONNECTION=""
-# third part yurl to polygon amoy network rpc node
-THIRD_PARTY_RPC_URL="" 
+# url to polygon amoy network rpc node
+RPC_URL="" 
 # third party contract address in the linea test network
 THIRD_PARTY_CONTRACT_ADDRESS=""
 # third party key in hex format with matic balance


### PR DESCRIPTION
THIRD_PARTY_RPC_URL -> RPC_URL

Without this change the tests won't run because index.ts refers to "RPC_URL".
Alernatively, the reference in index.ts could be updated to be "THIRD_PARTY_RPC_URL".