### PR TITLE
Autofix: Unable to add a specific issuer when created by the issuer node for ZeroKnowledgeProofRequest and issueCredential() in generateProofs()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -311,40 +311,79 @@ async function transitStateThirdPartyDID() {
 }
 
 async function generateProofs(useMongoStore = false) {
+async function generateProofs(useMongoStore = false) {
+  console.log('=============== generate proofs ===============');
   console.log('=============== generate proofs ===============');
 
+
+  let dataStorage, credentialWallet, identityWallet;
   let dataStorage, credentialWallet, identityWallet;
   if (useMongoStore) {
+  if (useMongoStore) {
+    ({ dataStorage, credentialWallet, identityWallet } = await initMongoDataStorageAndWallets(
     ({ dataStorage, credentialWallet, identityWallet } = await initMongoDataStorageAndWallets(
       defaultNetworkConnection
-    ));
-  } else {
-    ({ dataStorage, credentialWallet, identityWallet } = await initInMemoryDataStorageAndWallets(
       defaultNetworkConnection
     ));
+    ));
+  } else {
+  } else {
+    ({ dataStorage, credentialWallet, identityWallet } = await initInMemoryDataStorageAndWallets(
+    ({ dataStorage, credentialWallet, identityWallet } = await initInMemoryDataStorageAndWallets(
+      defaultNetworkConnection
+      defaultNetworkConnection
+    ));
+    ));
+  }
   }
 
+
+  const circuitStorage = await initCircuitStorage();
   const circuitStorage = await initCircuitStorage();
   const proofService = await initProofService(
+  const proofService = await initProofService(
+    identityWallet,
     identityWallet,
     credentialWallet,
+    credentialWallet,
+    dataStorage.states,
     dataStorage.states,
     circuitStorage
+    circuitStorage
+  );
   );
 
+
+  const { did: userDID, credential: authBJJCredentialUser } = await identityWallet.createIdentity({
   const { did: userDID, credential: authBJJCredentialUser } = await identityWallet.createIdentity({
     ...defaultIdentityCreationOptions
+    ...defaultIdentityCreationOptions
+  });
   });
 
+
+  console.log('=============== user did ===============');
   console.log('=============== user did ===============');
   console.log(userDID.string());
+  console.log(userDID.string());
+
 
   const { did: issuerDID, credential: issuerAuthBJJCredential } =
+  const { did: issuerDID, credential: issuerAuthBJJCredential } =
+    await identityWallet.createIdentity({ ...defaultIdentityCreationOptions });
     await identityWallet.createIdentity({ ...defaultIdentityCreationOptions });
 
+
   const credentialRequest = createKYCAgeCredential(userDID);
+  const credentialRequest = createKYCAgeCredential(userDID);
+  // Initialize merkle tree for issuer DID
+  await identityWallet.getDIDTreeModel(issuerDID);
+
+  // Issue credential
   const credential = await identityWallet.issueCredential(issuerDID, credentialRequest);
 
+
+  await dataStorage.credential.saveCredential(credential);
   await dataStorage.credential.saveCredential(credential);
 
   console.log('================= generate Iden3SparseMerkleTreeProof =======================');


### PR DESCRIPTION
Modified the generateProofs function to initialize the merkle tree for the issuer DID before attempting to issue a credential. This should resolve the 'Cannot read properties of undefined (reading 'find')' error. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    